### PR TITLE
WIP : Tessellation rotation

### DIFF
--- a/gwemopt/catalog.py
+++ b/gwemopt/catalog.py
@@ -144,7 +144,7 @@ def get_catalog(params, map_struct):
     index = np.argmin(np.abs(prob_cumsum - cl)) + 1
     prob_scaled[prob_indexes[index:]] = 0.0
     prob_scaled = prob_scaled**n
-    prob_scaled = prob_scaled / np.nansum(prob_scaled)
+#    prob_scaled = prob_scaled / np.nansum(prob_scaled)
 
     theta = 0.5 * np.pi - dec * 2 * np.pi /360.0
     phi = ra * 2 * np.pi /360.0

--- a/gwemopt/tiles.py
+++ b/gwemopt/tiles.py
@@ -297,3 +297,85 @@ def tesselation_packing(config_struct):
         fid.write('%d %.5f %.5f\n'%(ii,ra[ii],dec[ii]))
     fid.close()
 
+def open_tess(path_tess):
+    """
+    This function open a tessellation file and return two list containing
+    the information of each tile center (a list of RA and a list of Dec).
+  
+    Input parameters
+    ----------------   
+    path_tess : str
+        path of the tessellation file
+    """        
+    tesslation = open(path_tess,'r')
+    
+    list_ra = []
+    list_dec = []
+    
+    for line in tesslation:
+        line = line.strip('\n').split(' ')
+        
+            
+        list_ra += [float(line[1])]
+        list_dec += [float(line[2])]
+    
+    tesslation.close()
+    
+    return list_ra, list_dec
+
+
+def rotation_tiling(path_tess, ra_center=0, dec_center=90, name='rot'):
+    """
+    This function open a tessellation file and creat a new tessellation
+    by rotating the previous one to get ra_center, dec_center considered as
+    the new center of the created tessellation.
+    
+    By default ra_center=0 and dec_center=90, that make an 90degrees rotation
+    in a positive dec orientation.
+    
+    Input parameters
+    ----------------   
+    path_tess : str
+        path of the tessellation file that you want to rotate
+    ra_center : float
+        RA of the new point that you want to consider as center
+    dec_center : float
+        Dec of the new point that you want to consider as center
+    name = str
+        string added to the name of the tessellation, default = 'rot'
+    """
+    
+    list_ra, list_dec = open_tess(path_tess)
+    
+    #for all ra,dec we apply the rotation and take care of the periodic limit conditions
+    for i in range(len(list_ra)):
+        
+        current_ra = list_ra[i]
+        current_dec = list_dec[i]
+        
+        #apply the rotation
+        current_ra += ra_center
+        current_dec += dec_center
+        
+        #security for the periodic limit conditions
+        #for dec
+        if current_dec > 90.:
+            current_dec = -180. + current_dec
+        elif current_dec < -90.:
+            current_dec = 180 - current_dec        
+    
+        #for ra
+        if current_ra > 360.:
+            current_ra = current_ra - 360.
+        elif current_ra < 0.:
+            current_ra = 360. + current_ra
+        
+        list_ra[i] = current_ra
+        list_dec[i] = current_dec
+         
+    #open and write the result in a new tessellation file
+    tess_rot = open(path_tess.replace(".tess",'')+"_{}.tess".format(name),'w')
+    for n in range(len(list_ra)):
+        tess_rot.write('%d %.5f %.5f\n'%(n,list_ra[n],list_dec[n]))
+    tess_rot.close()
+    return


### PR DESCRIPTION
I started to implement the rotation tools for the rotation to get ride of the poles issues.

I added a function to rotate a given tessellation, I did not chose to change the functions that create the tessellation itself because there is two of them (tesselation_packing and tesselation_spiral) and if you do another one in the futur the tool to rotate will still work in this way.

I putted by default a rotation of +90deg in Dec but it can be changed in input.
I putted by default as name of the new tessellation : [telescope]_rot.tess, but it can be changed in input.

Questions on how to implement it in gwemopt:
-Do you want this new tessellation to be created by default for each telescop? (at the same time we create the first one)
-How do you chose to take the rotated tessellation and not the usual one?
    *By checking only the position of the 2D max probability of the skymap?
    *By checking the number of tiles in the 90% skymap which are near poles?
    *By checking if there is problematic tiles?
    *Other method ?

If we chose the use that tool that mean we have to add a security which check that the rotated tessellation is available before calling it (as it exist for the usual one).

Here are some plots of the results:
-normal tessellation (using packing method):


![test_rot_init](https://user-images.githubusercontent.com/44273935/54024567-6e20f980-4198-11e9-9c79-64be3a1e99fe.png)
![test_rot_init2](https://user-images.githubusercontent.com/44273935/54024569-6e20f980-4198-11e9-8664-646d8388def9.png)

-rotated tessellation taking previous one as input: 
![test_rot](https://user-images.githubusercontent.com/44273935/54024595-86911400-4198-11e9-8e1d-3a41c885ae9a.png)
![test_rot2](https://user-images.githubusercontent.com/44273935/54024596-86911400-4198-11e9-8223-5815854819f5.png)

Anyway i need to test the results on a skymap near pole before merging anything, I will let you know.

(Sorry for the long post)
