### PR TITLE
Added possibility to combine closeby galaxy in a single tile for tilesType==galaxies

### DIFF
--- a/bin/gwemopt_run
+++ b/bin/gwemopt_run
@@ -132,6 +132,8 @@ def parse_commandline():
     parser.add_option("--powerlaw_n",default=1.0,type=float)
     parser.add_option("--powerlaw_dist_exp",default=0,type=float)
 
+    parser.add_option("--galaxies_FoV_sep",default=0.0,type=float)
+
     parser.add_option("--doFootprint", action="store_true", default=False)
     parser.add_option("--footprint_ra",default=30.0,type=float)
     parser.add_option("--footprint_dec",default=60.0,type=float)
@@ -250,6 +252,7 @@ def params_struct(opts):
     params["powerlaw_cl"] = opts.powerlaw_cl
     params["powerlaw_n"] = opts.powerlaw_n
     params["powerlaw_dist_exp"] = opts.powerlaw_dist_exp
+    params["galaxies_FoV_sep"] = opts.galaxies_FoV_sep
 
     params["doPlots"] = opts.doPlots
     params["doMovie"] = opts.doMovie

--- a/config/Lisnyky-AZT8.config
+++ b/config/Lisnyky-AZT8.config
@@ -8,7 +8,6 @@ FOV 0.26
 FOV_coverage_type square
 FOV_type square
 slew_rate 7
-readout  9,5
+readout  9.5
 filt r
 horizon 30
-

--- a/gwemopt/catalog.py
+++ b/gwemopt/catalog.py
@@ -218,7 +218,7 @@ def get_catalog(params, map_struct):
 
     # Set nan values to zero
     Sloc[np.isnan(Sloc)] = 0
-    print(len(np.where(Sloc != 0)[0]))
+
     S = Sloc*Slum*Sdet
     prob = np.zeros(map_struct["prob"].shape)
     if params["galaxy_grade"] == "Sloc":

--- a/gwemopt/scheduler.py
+++ b/gwemopt/scheduler.py
@@ -154,7 +154,7 @@ def get_order(params, tile_struct, tilesegmentlists, exposurelist, observatory, 
             if tilesegmentlist.intersects_segment(exposurelist[ii]):
                 if tile_struct[key]["prob"] == 0: continue
                 if "dec_constraint" in config_struct:
-                    print(tile_struct[key]["dec"],dec_min,dec_max)
+                    #print(tile_struct[key]["dec"],dec_min,dec_max)
                     if (tile_struct[key]["dec"] < dec_min) or (tile_struct[key]["dec"] > dec_max): continue
                 exposureids.append(key)
                 probs.append(tile_struct[key]["prob"])
@@ -499,7 +499,8 @@ def scheduler(params, config_struct, tile_struct):
     coverage_struct["area"] = np.array(coverage_struct["area"])
     coverage_struct["filters"] = np.array(coverage_struct["filters"])
     coverage_struct["FOV"] = config_struct["FOV"]*np.ones((len(coverage_struct["filters"]),))
-    coverage_struct["telescope"] = [config_struct["telescope"]]*len(coverage_struct["filters"])
+    #coverage_struct["telescope"] = [config_struct["telescope"]]*len(coverage_struct["filters"])
+    coverage_struct["telescope"] = [config_struct]*len(coverage_struct["filters"])
 
     return coverage_struct
 

--- a/gwemopt/tests/test_schedule.py
+++ b/gwemopt/tests/test_schedule.py
@@ -108,6 +108,8 @@ def params_struct(skymap, gpstime, tobs=None, filt=['r'],
     params["powerlaw_n"] = 1.0
     params["powerlaw_dist_exp"] = 0.0
 
+    params["galaxies_FoV_sep"] = 0.0
+
     params["doPlots"] = False
     params["doMovie"] = False
     params["doObservability"] = True

--- a/gwemopt/tiles.py
+++ b/gwemopt/tiles.py
@@ -16,24 +16,54 @@ import gwemopt.quadrants
 import gwemopt.moc
 
 def galaxy(params, map_struct, catalog_struct):
-
     nside = params["nside"]
 
     tile_structs = {}
     for telescope in params["telescopes"]:
+
         config_struct = params["config"][telescope]
+
+        # Merge in single pointing galaxies separating by less than FOV*ratio_FOV
+        # Take galaxy with highest proba at the center of new pointing
+        #ratio_FOV = 0.3
+        FOV = params["config"][telescope]['FOV']
+        new_ra = []
+        new_dec = []
+        new_Sloc = []
+        new_S = []
+        indexes2keep = [bool(i) for i in np.ones(len(catalog_struct["ra"]))]
+        cnt=0
+        for ra, dec, Sloc, S in zip(catalog_struct["ra"], catalog_struct["dec"], catalog_struct["Sloc"], catalog_struct["S"]):
+            mask = ((FOV * params['galaxies_FoV_sep'])**2 >= (catalog_struct["ra"] - ra)**2 + (catalog_struct["dec"] - dec)**2) & (indexes2keep)
+            if indexes2keep[cnt]:
+                new_ra.append(ra)
+                new_dec.append(dec)
+                new_Sloc.append(np.sum(catalog_struct["Sloc"][mask]))
+                new_S.append(np.sum(catalog_struct["S"][mask]))
+                # discard galaxies already taken into account
+                indexes2discard = np.where(mask)[0]
+                for index in indexes2discard:
+                    indexes2keep[index] = False
+            cnt+=1
+
+        # redefine catalog_struct
+        catalog_struct_new = {}
+        catalog_struct_new["ra"] = new_ra
+        catalog_struct_new["dec"] = new_dec
+        catalog_struct_new["Sloc"] = new_Sloc
+        catalog_struct_new["S"] = new_S
 
         moc_struct = {}
         cnt = 0
-        for ra, dec, Sloc, S in zip(catalog_struct["ra"], catalog_struct["dec"], catalog_struct["Sloc"], catalog_struct["S"]):
+        for ra, dec, Sloc, S in zip(catalog_struct_new["ra"], catalog_struct_new["dec"], catalog_struct_new["Sloc"], catalog_struct_new["S"]):
             moc_struct[cnt] = gwemopt.moc.Fov2Moc(params, config_struct, telescope, ra, dec, nside)
             cnt = cnt + 1
-
+        
         tile_struct = powerlaw_tiles_struct(params, config_struct, telescope, map_struct, moc_struct)
         tile_struct = gwemopt.segments.get_segments_tiles(params, config_struct, tile_struct)
 
         cnt = 0
-        for ra, dec, Sloc, S in zip(catalog_struct["ra"], catalog_struct["dec"], catalog_struct["Sloc"], catalog_struct["S"]):
+        for ra, dec, Sloc, S in zip(catalog_struct_new["ra"], catalog_struct_new["dec"], catalog_struct_new["Sloc"], catalog_struct_new["S"]):
             tile_struct[cnt]['prob'] = Sloc
             cnt = cnt + 1
 

--- a/gwemopt/tiles.py
+++ b/gwemopt/tiles.py
@@ -23,10 +23,10 @@ def galaxy(params, map_struct, catalog_struct):
 
         config_struct = params["config"][telescope]
 
-        # Merge in single pointing galaxies separating by less than FOV*ratio_FOV
+        # Combine in a single pointing, galaxies that are distant by
+        # less than FoV * params['galaxies_FoV_sep']
         # Take galaxy with highest proba at the center of new pointing
-        #ratio_FOV = 0.3
-        FOV = params["config"][telescope]['FOV']
+        FoV = params["config"][telescope]['FOV']
         new_ra = []
         new_dec = []
         new_Sloc = []

--- a/gwemopt/tiles.py
+++ b/gwemopt/tiles.py
@@ -34,7 +34,7 @@ def galaxy(params, map_struct, catalog_struct):
         indexes2keep = [bool(i) for i in np.ones(len(catalog_struct["ra"]))]
         cnt=0
         for ra, dec, Sloc, S in zip(catalog_struct["ra"], catalog_struct["dec"], catalog_struct["Sloc"], catalog_struct["S"]):
-            mask = ((FOV * params['galaxies_FoV_sep'])**2 >= (catalog_struct["ra"] - ra)**2 + (catalog_struct["dec"] - dec)**2) & (indexes2keep)
+            mask = ((FoV * params['galaxies_FoV_sep'])**2 >= (catalog_struct["ra"] - ra)**2 + (catalog_struct["dec"] - dec)**2) & (indexes2keep)
             if indexes2keep[cnt]:
                 new_ra.append(ra)
                 new_dec.append(dec)

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ install_requires = [
 # test dependencies
 tests_require = [
     'pytest>=3.1',
+    'pytest-runner',
     'freezegun',
     'sqlparse',
     'bs4',


### PR DESCRIPTION
Combine galaxies in a single tile for tilesType==galaxies when they are distant by less than FoV * ratio . The ratio on the FoV is set through the parameter 'galaxies_FoV_sep' which set to 0 by default.

Minor changes regarding uncommented print used for testing

One change I am not certain: scheduler.py line 502 : I modified config_struct["telescope"] to config_struct as there is no 'telescope' keyword in this dictionary. 

Added pytest-runner to the test-requirements in setup.py.