### PR TITLE
Added possibility to consider tiles only observable for a given amount of time

### DIFF
--- a/config/ATLAS.config
+++ b/config/ATLAS.config
@@ -12,3 +12,4 @@ tesselationFile ../input/ATLAS.tess
 slew_rate 15
 readout 6
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Abastunami-T48.config
+++ b/config/Abastunami-T48.config
@@ -12,3 +12,4 @@ slew_rate 20
 readout 10
 filt r
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Abastunami-T48.config
+++ b/config/Abastunami-T48.config
@@ -13,3 +13,4 @@ readout 10
 filt r
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/Abastunami-T70.config
+++ b/config/Abastunami-T70.config
@@ -12,3 +12,4 @@ slew_rate 20
 readout 10
 filt r
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Abastunami-T70.config
+++ b/config/Abastunami-T70.config
@@ -13,3 +13,4 @@ readout 10
 filt r
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/BlackGEM.config
+++ b/config/BlackGEM.config
@@ -12,3 +12,4 @@ tesselationFile ../input/BlackGEM.tess
 slew_rate 0.5
 readout 0
 horizon 30
+overhead_per_exposure 0.0

--- a/config/CFHT.config
+++ b/config/CFHT.config
@@ -12,3 +12,4 @@ tesselationFile ../input/CFHT.tess
 slew_rate 15
 readout 40
 horizon 30
+overhead_per_exposure 0.0

--- a/config/F60.config
+++ b/config/F60.config
@@ -12,3 +12,4 @@ slew_rate 6
 readout 5
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/F60.config
+++ b/config/F60.config
@@ -11,3 +11,4 @@ FOV_type square
 slew_rate 6
 readout 5
 horizon 30
+overhead_per_exposure 0.0

--- a/config/FAKE.config
+++ b/config/FAKE.config
@@ -11,3 +11,4 @@ FOV_type circle
 tesselationFile ../input/FAKE.tess
 slew_rate 0.5
 horizon 30
+overhead_per_exposure 0.0

--- a/config/GWAC.config
+++ b/config/GWAC.config
@@ -12,3 +12,4 @@ tesselationFile ../input/GWAC.tess
 slew_rate 3.0
 readout 4
 horizon 30
+overhead_per_exposure 0.0

--- a/config/IRIS.config
+++ b/config/IRIS.config
@@ -13,3 +13,4 @@ slew_rate 10
 readout 8.4
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/IRIS.config
+++ b/config/IRIS.config
@@ -12,3 +12,4 @@ tesselationFile ../input/IRIS.tess
 slew_rate 10
 readout 8.4
 horizon 30
+overhead_per_exposure 0.0

--- a/config/LSST.config
+++ b/config/LSST.config
@@ -12,3 +12,4 @@ tesselationFile ../input/LSST.tess
 slew_rate 6.3
 readout 2
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Lisnyky-AZT8.config
+++ b/config/Lisnyky-AZT8.config
@@ -11,3 +11,4 @@ slew_rate 7
 readout  9.5
 filt r
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Lisnyky-AZT8.config
+++ b/config/Lisnyky-AZT8.config
@@ -12,3 +12,4 @@ readout  9.5
 filt r
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/Makes-60.config
+++ b/config/Makes-60.config
@@ -11,3 +11,4 @@ slew_rate 4
 readout 20
 filt r
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Makes-60.config
+++ b/config/Makes-60.config
@@ -12,3 +12,4 @@ readout 20
 filt r
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/NOWT.config
+++ b/config/NOWT.config
@@ -12,3 +12,4 @@ slew_rate 7
 readout 28
 filt  r
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Nickel.config
+++ b/config/Nickel.config
@@ -12,3 +12,4 @@ tesselationFile ../input/Nickel.tess
 slew_rate 15
 readout 40
 horizon 30
+overhead_per_exposure 0.0

--- a/config/OAJ.config
+++ b/config/OAJ.config
@@ -11,4 +11,5 @@ tesselationFile ../input/OAJ.tess
 slew_rate 4
 readout 12
 horizon 30
-filt r’
+filt r
+overhead_per_exposure 0.0

--- a/config/OAJ.config
+++ b/config/OAJ.config
@@ -13,3 +13,4 @@ readout 12
 horizon 30
 filt r
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/OSN.config
+++ b/config/OSN.config
@@ -11,3 +11,4 @@ slew_rate 0
 readout 15
 filt BVRI
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/OSN.config
+++ b/config/OSN.config
@@ -10,3 +10,4 @@ FOV_type square
 slew_rate 0
 readout 15
 filt BVRI
+overhead_per_exposure 0.0

--- a/config/PS1.config
+++ b/config/PS1.config
@@ -12,3 +12,4 @@ tesselationFile ../input/PS1.tess
 slew_rate 0.6
 readout 3
 horizon 30
+overhead_per_exposure 0.0

--- a/config/SVOM-VT.config
+++ b/config/SVOM-VT.config
@@ -11,3 +11,4 @@ FOV_type square
 slew_rate 0.375
 readout 2
 horizon 30
+overhead_per_exposure 0.0

--- a/config/SWOPE.config
+++ b/config/SWOPE.config
@@ -12,3 +12,4 @@ tesselationFile ../input/SWOPE.tess
 slew_rate 15
 readout 40
 horizon 30
+overhead_per_exposure 0.0

--- a/config/ShAO-T60.config
+++ b/config/ShAO-T60.config
@@ -13,3 +13,4 @@ readout 3
 filters Rc
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/ShAO-T60.config
+++ b/config/ShAO-T60.config
@@ -12,3 +12,4 @@ slew_rate 30
 readout 3
 filters Rc
 horizon 30
+overhead_per_exposure 0.0

--- a/config/TCA.config
+++ b/config/TCA.config
@@ -11,4 +11,8 @@ tesselationFile ../input/TCA.tess
 slew_rate 20
 readout 5
 filt r
-horizon 10
+horizon 15
+dec_constraint -25,90
+moon_constraint 30.0
+overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/TCH.config
+++ b/config/TCH.config
@@ -11,4 +11,8 @@ tesselationFile ../input/TCH.tess
 slew_rate 20
 readout 5
 filt r
-horizon 10
+horizon 15
+dec_constraint -90,30
+moon_constraint 30.0
+overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/TNT.config
+++ b/config/TNT.config
@@ -14,3 +14,4 @@ filt r
 horizon 30
 dec_constraint -10,68
 moon_constraint 30.0
+overhead_per_exposure 0.0

--- a/config/TNT.config
+++ b/config/TNT.config
@@ -15,3 +15,4 @@ horizon 30
 dec_constraint -10,68
 moon_constraint 30.0
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/config/TRE.config
+++ b/config/TRE.config
@@ -15,4 +15,4 @@ horizon 20
 dec_constraint -90,40
 moon_constraint 30.0
 overhead_per_exposure 0.0
-min_observability_duration 0.1
+min_observability_duration 2.0

--- a/config/TRE.config
+++ b/config/TRE.config
@@ -11,4 +11,8 @@ tesselationFile ../input/TRE.tess
 slew_rate 20
 readout 10
 filt None
-horizon 10
+horizon 20
+dec_constraint -90,40
+moon_constraint 30.0
+overhead_per_exposure 0.0
+min_observability_duration 0.1

--- a/config/Zadko.config
+++ b/config/Zadko.config
@@ -12,3 +12,4 @@ slew_rate 6
 readout 20
 filt gri
 horizon 30
+overhead_per_exposure 0.0

--- a/config/Zadko.config
+++ b/config/Zadko.config
@@ -13,3 +13,4 @@ readout 20
 filt gri
 horizon 30
 overhead_per_exposure 0.0
+min_observability_duration 2.0

--- a/gwemopt/tests/test_schedule.py
+++ b/gwemopt/tests/test_schedule.py
@@ -79,7 +79,7 @@ def params_struct(skymap, gpstime, tobs=None, filt=['r'],
         observer = ephem.Observer()
         observer.lat = str(params["config"][telescope]["latitude"])
         observer.lon = str(params["config"][telescope]["longitude"])
-        observer.horizon = str(-12.0)
+        observer.horizon = str(params["config"][telescope]["horizon"])
         observer.elevation = params["config"][telescope]["elevation"]
         params["config"][telescope]["observer"] = observer
 
@@ -96,6 +96,16 @@ def params_struct(skymap, gpstime, tobs=None, filt=['r'],
         params["catalogDir"] = catalog_directory
         params["galaxy_catalog"] = "GLADE"
         params["galaxy_grade"] = "S"
+        params["writeCatalog"] = False
+        params["catalog_n"] = 1.0
+        params["powerlaw_dist_exp"] = 1.0
+    elif tele in ['TRE']:
+        params["tilesType"] = "moc"
+    elif tele in ['TNT']:
+        params["tilesType"] = "galaxy"
+        params["catalogDir"] = catalog_directory
+        params["galaxy_catalog"] = "GLADE"
+        params["galaxy_grade"] = "Sloc"
         params["writeCatalog"] = False
         params["catalog_n"] = 1.0
         params["powerlaw_dist_exp"] = 1.0
@@ -237,8 +247,8 @@ def test_scheduler():
     skymap = os.path.join(testpath, 'data/MS190227n_bayestar.fits.gz')
     gpstime = 1235311089.400738
 
-    teles=['ZTF','KPED']
-    doReferences_list = [True,False]
+    teles=['ZTF','KPED', 'TRE', 'TNT']
+    doReferences_list = [True,False, False, False]
     for tele,doReferences in zip(teles,doReferences_list): 
         params = params_struct(skymap, gpstime, tele=tele,
                                doReferences=doReferences)

--- a/gwemopt/tests/test_schedule.py
+++ b/gwemopt/tests/test_schedule.py
@@ -79,7 +79,7 @@ def params_struct(skymap, gpstime, tobs=None, filt=['r'],
         observer = ephem.Observer()
         observer.lat = str(params["config"][telescope]["latitude"])
         observer.lon = str(params["config"][telescope]["longitude"])
-        observer.horizon = str(params["config"][telescope]["horizon"])
+        observer.horizon = str(-12.0)
         observer.elevation = params["config"][telescope]["elevation"]
         params["config"][telescope]["observer"] = observer
 

--- a/gwemopt/tiles.py
+++ b/gwemopt/tiles.py
@@ -143,6 +143,24 @@ def powerlaw_tiles_struct(params, config_struct, telescope, map_struct, tile_str
         for ii in range(len(params["exposuretimes"])):
             ranked_tile_times[ranked_tile_probs>0,ii] = params["exposuretimes"][ii]
         for key, prob, exposureTime, tileprob in zip(keys, ranked_tile_probs, ranked_tile_times, tile_probs):
+
+            # Try to load the minimum duration of time from telescope config file
+            # Otherwise set it to zero
+            try:
+                min_obs_duration = config_struct["min_observability_duration"] / 24
+            except:
+                min_obs_duration = 0.0
+
+            # Check that a given tile is observable a minimum amount of time
+            # If not set the proba associated to the tile to zero
+            if 'segmentlist' and 'prob' in tile_struct[key] and tile_struct[key]['segmentlist'] and min_obs_duration > 0.0:
+                observability_duration = 0.0 
+                for counter in range(len(tile_struct[key]['segmentlist'])):
+                    observability_duration += tile_struct[key]['segmentlist'][counter][1] - tile_struct[key]['segmentlist'][counter][0]
+                if tile_struct[key]['prob'] > 0.0 and observability_duration < min_obs_duration: 
+                   tileprob = 0.0
+
+
             tile_struct[key]["prob"] = tileprob
             if prob == 0.0:
                 tile_struct[key]["exposureTime"] = 0.0
@@ -173,6 +191,22 @@ def powerlaw_tiles_struct(params, config_struct, telescope, map_struct, tile_str
 
         keys = tile_struct.keys()
         for key, prob, exposureTime, tileprob in zip(keys, ranked_tile_probs, ranked_tile_times, tile_probs):
+            # Try to load the minimum duration of time from telescope config file
+            # Otherwise set it to zero
+            try:
+                min_obs_duration = config_struct["min_observability_duration"] / 24
+            except:
+                min_obs_duration = 0.0
+
+            # Check that a given tile is observable a minimum amount of time
+            # If not set the proba associated to the tile to zero
+            if 'segmentlist' and 'prob' in tile_struct[key] and tile_struct[key]['segmentlist'] and min_obs_duration > 0.0:
+                observability_duration = 0.0 
+                for counter in range(len(tile_struct[key]['segmentlist'])):
+                    observability_duration += tile_struct[key]['segmentlist'][counter][1] - tile_struct[key]['segmentlist'][counter][0]
+                if tile_struct[key]['prob'] > 0.0 and observability_duration < min_obs_duration: 
+                    prob = 0.0
+
             tile_struct[key]["prob"] = prob
             tile_struct[key]["exposureTime"] = exposureTime
             tile_struct[key]["nexposures"] = int(np.floor(exposureTime/config_struct["exposuretime"]))


### PR DESCRIPTION
There are 3 changes here:   

- added overhead_per_exposure in each telescope config files to avoid the code to crash when not present. A better option would be to set a try / except condition in the code where this is used.

- Added min_observability_duration parameter in the telescope config file (expressed in hours). This parameter is used in tiles.py as a threshold to consider only tiles that are observable for at least this duration. Otherwise the probability of  the tile is set to 0. @mcoughlin, you might want to check whether this change does not break anything in the code. From my side, it works fine, as well as the test_schedule.py.   
If this parameter is not present in the config file, the value is simply set to zero, and nothing is modified in the code.

- Added TRE and TNT telescopes in the test_schedule.py to make the test more robust.
 