### PR TITLE
Depend on ephem, not pyephem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     'mocpy',
     'astroquery',
     'astroplan',
-    'pyephem',
+    'ephem',
     'pyyaml',
     'VOEventLib',
     'joblib',


### PR DESCRIPTION
The `python3-ephem` package from Debian satisfies an install_requires dependency for `ephem`, but not for `pyephem`.