### PR TITLE
Deal with no compatible galaxies, add AGN_flag for mangrove

### DIFF
--- a/ToO/ToO_manager.py
+++ b/ToO/ToO_manager.py
@@ -279,7 +279,7 @@ def init_observation_plan(VO_dic, skymappath, dirpath="", filename=""):
     params["galaxy_catalog"] = "mangrove"
     params["doCatalog"] = False
     params["galaxy_grade"] = 'Smass'
-    params["AGN_flag"] = False
+    params["AGN_flag"] = True
     params["writeCatalog"] = False
     params["doParallel"] = False
     params["Ncores"] = 2
@@ -448,7 +448,7 @@ def Observation_plan_multiple(telescopes, VO_dic, trigger_id, params, map_struct
         map_struct, catalog_struct = gwemopt.catalog.get_catalog(params, map_struct)
         
         #add here a security which for the use of the 2D probability if no compatible galaxies are found in the catalog
-        if len(catalog_struct['ra']) == 0:
+        if catalog_struct['CompatibleGal'] == False:
             print("No compatible galaxy found in the skymap, go back to the 2D proba for tiling telescopes")
             map_struct = copy.deepcopy(map_struct_input) 
 
@@ -636,9 +636,6 @@ def Observation_plan_multiple(telescopes, VO_dic, trigger_id, params, map_struct
         #if storeGal: send_ObsPlan_galaxies_to_DB(galaxies_table, trigger_id)
 
     #        return np.transpose(np.array([rank_id, ra_vec, dec_vec, grade_vec])), galaxies_table
-
-    print("tiles_tables =", tiles_tables)
-    print("galaxies_table =", galaxies_table)
 
     return tiles_tables, galaxies_table
 

--- a/ToO/ToO_manager.py
+++ b/ToO/ToO_manager.py
@@ -240,7 +240,7 @@ def init_observation_plan(VO_dic, skymappath, dirpath="", filename=""):
     params["powerlaw_dist_exp"] = 1.0
 
     params["doPlots"] = False
-    params["doPlots"] = True
+    params["doPlots"] = False
     params["doMovie"] = False
     # params["doObservability"] = True
     params["doObservability"] = False
@@ -271,13 +271,15 @@ def init_observation_plan(VO_dic, skymappath, dirpath="", filename=""):
     params["doMaxTiles"] = False
     params["iterativeOverlap"] = 0.2
     params["maximumOverlap"] = 0.2
+    params["doTreasureMap"] = False
 
     params["catalog_n"] = 1.0
     params["doUseCatalog"] = False
     params["catalogDir"] = "../catalogs"
-    params["galaxy_catalog"] = "GLADE"
+    params["galaxy_catalog"] = "mangrove"
     params["doCatalog"] = False
-    params["galaxy_grade"] = 'Sloc'
+    params["galaxy_grade"] = 'Smass'
+    params["AGN_flag"] = False
     params["writeCatalog"] = False
     params["doParallel"] = False
     params["Ncores"] = 2
@@ -293,7 +295,7 @@ def init_observation_plan(VO_dic, skymappath, dirpath="", filename=""):
     params['doBalanceExposure'] = False
     params['doMovie_supersched'] = False
     params['doOrderByObservability'] = False
-
+    params["doRASlice"] = False
     params["doSingleExposure"] = True
     params["filters"] = filt
     params["exposuretimes"] = exposuretimes
@@ -444,11 +446,14 @@ def Observation_plan_multiple(telescopes, VO_dic, trigger_id, params, map_struct
 
     if params["doCatalog"]:
         map_struct, catalog_struct = gwemopt.catalog.get_catalog(params, map_struct)
+        
+        #add here a security which for the use of the 2D probability if no compatible galaxies are found in the catalog
+        if len(catalog_struct['ra']) == 0:
+            print("No compatible galaxy found in the skymap, go back to the 2D proba for tiling telescopes")
+            map_struct = copy.deepcopy(map_struct_input) 
 
     if params["doPlots"]:
         gwemopt.plotting.skymap(params, map_struct)
-
-    print(stop)
 
     if params["doPlots"]:
         gwemopt.plotting.skymap(params, map_struct)
@@ -501,8 +506,6 @@ def Observation_plan_multiple(telescopes, VO_dic, trigger_id, params, map_struct
         gwemopt.plotting.tiles(params, map_struct, tile_structs)
         gwemopt.plotting.coverage(params, map_struct, coverage_struct)
         gwemopt.scheduler.summary(params,map_struct,coverage_struct)
-
-    print(stop)
 
     tiles_tables = {}
     for jj, telescope in enumerate(telescopes):
@@ -633,6 +636,10 @@ def Observation_plan_multiple(telescopes, VO_dic, trigger_id, params, map_struct
         #if storeGal: send_ObsPlan_galaxies_to_DB(galaxies_table, trigger_id)
 
     #        return np.transpose(np.array([rank_id, ra_vec, dec_vec, grade_vec])), galaxies_table
+
+    print("tiles_tables =", tiles_tables)
+    print("galaxies_table =", galaxies_table)
+
     return tiles_tables, galaxies_table
 
 def Observation_plan(telescope, VO_dic, trigger_id, params, map_struct_input):
@@ -759,6 +766,11 @@ def Observation_plan(telescope, VO_dic, trigger_id, params, map_struct_input):
 
     if params["doCatalog"]:
         map_struct, catalog_struct = gwemopt.catalog.get_catalog(params, map_struct)
+
+        #add here a security which for the use of the 2D probability if no compatible galaxies are found in the catalog
+        if len(catalog_struct['ra']) == 0:
+            print("No compatible galaxy found in the skymap, go back to the 2D proba for tiling telescopes")
+            map_struct = copy.deepcopy(map_struct_input)
 
     if params["tilesType"] == "moc":
         print("Generating MOC struct...")
@@ -1219,8 +1231,8 @@ def GW_treatment_alert(v, output_dic, file_log_s):
         else:
             LISTE_TELESCOPE_TILING = ["TRE", "TCH", "TCA"]
             max_nb_tiles_tiling = np.array([30, 30, 30])
-            #LISTE_TELESCOPE_TILING2 = ["FZU-Auger", "FZU-CTA-N"]
-            #max_nb_tiles_tiling2 = np.array([20,20])
+            LISTE_TELESCOPE_TILING2 = ["FZU-Auger", "FZU-CTA-N"]
+            max_nb_tiles_tiling2 = np.array([20,20])
             #LISTE_TELESCOPE_TILING = ["TRE", "TCH", "TCA", "FZU-Auger", "FZU-CTA-N"]
             #max_nb_tiles_tiling = np.array([100, 100, 100, 100, 100])
 
@@ -1254,13 +1266,13 @@ def GW_treatment_alert(v, output_dic, file_log_s):
         params["max_nb_tiles"] = max_nb_tiles_tiling
         aTables_tiling, galaxies_table = Observation_plan_multiple(LISTE_TELESCOPE_TILING, GW_vo, trigger_id, params, map_struct, 'Tiling')
         # Send data to DB and send xml files to telescopes through broker for tiling
-        print(stop)
+        
         #send_data(LISTE_TELESCOPE_TILING, params, aTables_tiling, galaxies_table, GW_vo, GW_dic, trigger_id, v, file_log_s, path_config, output_dic, message_obs, name_dic, Db_use=Db_use, gal2DB=False)
 
         #params["max_nb_tiles"] = max_nb_tiles_tiling2
         aTables_tiling2, galaxies_table2 = Observation_plan_multiple(LISTE_TELESCOPE_TILING2, GW_vo, trigger_id, params, map_struct, 'Tiling')
         # Send data to DB and send xml files to telescopes through broker for tiling
-        print(stop)
+        
         send_data(LISTE_TELESCOPE_TILING2, params, aTables_tiling2, galaxies_table2, GW_vo, GW_dic, trigger_id, v, file_log_s, path_config, output_dic, message_obs, name_dic, Db_use=Db_use, gal2DB=False)
 
         ### Galaxy targeting ###

--- a/gwemopt/catalog.py
+++ b/gwemopt/catalog.py
@@ -250,9 +250,10 @@ def get_catalog(params, map_struct):
         idx = np.arange(len(r)).astype(int)
 
     # this happens when we are using a tiny catalog...
-    #if np.all(Sloc == 0.0):
-    #    Sloc[:] = 1.0
-
+    CompatibleGal = True
+    if np.all(Sloc == 0.0):
+        Sloc[:] = 1.0
+        CompatibleGal = False
 
     #new version of the Slum calcul (from HOGWARTs)
     Lsun = 3.828e26
@@ -472,6 +473,9 @@ def get_catalog(params, map_struct):
     catalog_struct["Sloc"] = Sloc
     catalog_struct["S"] = S
     catalog_struct["Smass"] = Smass
+
+    catalog_struct["CompatibleGal"] = CompatibleGal
+
 
     if params["writeCatalog"]:
         catalogfile = os.path.join(params["outputDir"], 'catalog.csv')

--- a/gwemopt/catalog.py
+++ b/gwemopt/catalog.py
@@ -185,6 +185,8 @@ def get_catalog(params, map_struct):
         # Keep track of galaxy identifier
         GWGC, PGC, HyperLEDA = cat["GWGC_name"], cat["PGC"], cat["HyperLEDA_name"]
         _2MASS, SDSS = cat["2MASS_name"], cat["SDSS-DR12_name"]
+        #keep track of the AGN flag
+        AGN_flag = cat["AGN_flag"]
 
         idx = np.where(distmpc >= 0)[0]
         ra, dec = ra[idx], dec[idx]
@@ -194,7 +196,7 @@ def get_catalog(params, map_struct):
         stellarmass = stellarmass[idx]
         GWGC, PGC, HyperLEDA = GWGC[idx], PGC[idx], HyperLEDA[idx]
         _2MASS, SDSS = _2MASS[idx], SDSS[idx]
-        
+        AGN_flag = AGN_flag[idx]
 
         # Convert bytestring to unicode
         GWGC = GWGC.astype('U')
@@ -248,8 +250,8 @@ def get_catalog(params, map_struct):
         idx = np.arange(len(r)).astype(int)
 
     # this happens when we are using a tiny catalog...
-    if np.all(Sloc == 0.0):
-        Sloc[:] = 1.0
+    #if np.all(Sloc == 0.0):
+    #    Sloc[:] = 1.0
 
 
     #new version of the Slum calcul (from HOGWARTs)
@@ -376,6 +378,7 @@ def get_catalog(params, map_struct):
         GWGC, PGC, HyperLEDA = GWGC[idx], PGC[idx], HyperLEDA[idx]
         _2MASS, SDSS = _2MASS[idx], SDSS[idx]   
         stellarmass, magb = stellarmass[idx], magb[idx]
+        AGN_flag = AGN_flag[idx]
         if params["galaxy_grade"] == "Smass":
             Smass = Smass[idx]
 
@@ -405,6 +408,7 @@ def get_catalog(params, map_struct):
         GWGC, PGC, HyperLEDA = GWGC[idx], PGC[idx], HyperLEDA[idx]
         _2MASS, SDSS = _2MASS[idx], SDSS[idx]
         stellarmass, magb = stellarmass[idx], magb[idx]
+        AGN_flag = AGN_flag[idx]
         if params["galaxy_grade"] == "Smass":
             Smass = Smass[idx]
        
@@ -426,6 +430,7 @@ def get_catalog(params, map_struct):
         GWGC, PGC, HyperLEDA = GWGC[mask], PGC[mask], HyperLEDA[mask]
         _2MASS, SDSS = _2MASS[mask], SDSS[mask]
         stellarmass, magb = stellarmass[mask], magb[mask]
+        AGN_flag = AGN_flag[mask]
 
         if params["galaxy_grade"] == "Smass":
             Smass = Smass[mask]
@@ -446,6 +451,7 @@ def get_catalog(params, map_struct):
             GWGC, PGC, HyperLEDA = GWGC[idx], PGC[idx], HyperLEDA[idx]
             _2MASS, SDSS = _2MASS[idx], SDSS[idx]
             stellarmass, magb = stellarmass[idx], magb[idx]
+            AGN_flag = AGN_flag[idx]
 
             if params["galaxy_grade"] == "Smass":
                 Smass = Smass[idx]
@@ -490,15 +496,37 @@ def get_catalog(params, map_struct):
         elif params["galaxy_catalog"] == "mangrove":
 
             if params["galaxy_grade"] == "Smass":
-                fid.write("id, RAJ2000, DEJ2000, Smass, S, Sloc, Dist, z, GWGC, PGC, HyperLEDA, 2MASS, SDSS, B_mag, stellarmass\n")
-                for a, b, c, d, e, f, g, h, i, j, k, l, m, n in zip(ra, dec, Smass, S, Sloc, distmpc, z, GWGC, PGC, HyperLEDA, _2MASS, SDSS, magb, stellarmass):
-                    fid.write("%d, %.5f, %.5f, %.5e, %.5e, %.5e, %.4f, %.4f, %s, %s, %s, %s, %s, %s, %s\n" % (cnt, a, b, c, d, e, f, g, h, i, j, k, l, m, n))
-                    cnt = cnt + 1
+
+                if params["AGN_flag"]:
+
+                    fid.write("id, RAJ2000, DEJ2000, Smass, S, Sloc, Dist, z, GWGC, PGC, HyperLEDA, 2MASS, SDSS, B_mag, AGN_flag, stellarmass\n")
+                    for a, b, c, d, e, f, g, h, i, j, k, l, m, n, o in zip(ra, dec, Smass, S, Sloc, distmpc, z, GWGC, PGC, HyperLEDA, _2MASS, SDSS, magb, AGN_flag,stellarmass):
+                        fid.write("%d, %.5f, %.5f, %.5e, %.5e, %.5e, %.4f, %.4f, %s, %s, %s, %s, %s, %s, %s, %s\n" % (cnt, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o))
+                        cnt = cnt + 1
+                    
+                else:
+
+                    fid.write("id, RAJ2000, DEJ2000, Smass, S, Sloc, Dist, z, GWGC, PGC, HyperLEDA, 2MASS, SDSS, B_mag, stellarmass\n")
+                    for a, b, c, d, e, f, g, h, i, j, k, l, m, n in zip(ra, dec, Smass, S, Sloc, distmpc, z, GWGC, PGC, HyperLEDA, _2MASS, SDSS, magb, stellarmass):
+                        fid.write("%d, %.5f, %.5f, %.5e, %.5e, %.5e, %.4f, %.4f, %s, %s, %s, %s, %s, %s, %s\n" % (cnt, a, b, c, d, e, f, g, h, i, j, k, l, m, n))
+                        cnt = cnt + 1
+
+
             else:
-                fid.write("id, RAJ2000, DEJ2000, Sloc, S, Dist, z, GWGC, PGC, HyperLEDA, 2MASS, SDSS\n")
-                for a, b, c, d, e, f, g, h, i, j, k in zip(ra, dec, Sloc, S, distmpc, z, GWGC, PGC, HyperLEDA, _2MASS, SDSS):
-                    fid.write("%d, %.5f, %.5f, %.5e, %.5e, %.4f, %.4f, %s, %s, %s, %s, %s\n" % (cnt, a, b, c, d, e, f, g, h, i, j, k))
-                    cnt = cnt + 1
+
+                if params["AGN_flag"]:
+
+                    fid.write("id, RAJ2000, DEJ2000, Sloc, S, Dist, z, GWGC, PGC, HyperLEDA, 2MASS, SDSS, AGN_flag\n")
+                    for a, b, c, d, e, f, g, h, i, j, k, l in zip(ra, dec, Sloc, S, distmpc, z, GWGC, PGC, HyperLEDA, _2MASS, SDSS, AGN_flag):
+                        fid.write("%d, %.5f, %.5f, %.5e, %.5e, %.4f, %.4f, %s, %s, %s, %s, %s, %s\n" % (cnt, a, b, c, d, e, f, g, h, i, j, k, l))
+                        cnt = cnt + 1
+
+                else:
+
+                    fid.write("id, RAJ2000, DEJ2000, Sloc, S, Dist, z, GWGC, PGC, HyperLEDA, 2MASS, SDSS\n")
+                    for a, b, c, d, e, f, g, h, i, j, k in zip(ra, dec, Sloc, S, distmpc, z, GWGC, PGC, HyperLEDA, _2MASS, SDSS):
+                        fid.write("%d, %.5f, %.5f, %.5e, %.5e, %.4f, %.4f, %s, %s, %s, %s, %s\n" % (cnt, a, b, c, d, e, f, g, h, i, j, k))
+                        cnt = cnt + 1
                 
         else:
             fid.write("id, RAJ2000, DEJ2000, Sloc, S, Dist, z\n")

--- a/gwemopt/coverage.py
+++ b/gwemopt/coverage.py
@@ -229,8 +229,7 @@ def powerlaw(params, map_struct, tile_structs,previous_coverage_struct=None):
                 sat_sun_restriction = config_struct["sat_sun_restriction"]
             except:
                 sat_sun_restriction = 0.0
-            print("sat_sun_restriction =", sat_sun_restriction)
-            print("params[tilesType] =", params["tilesType"])
+            
             if not params["tilesType"] == "galaxy":
                 tile_struct = gwemopt.tiles.powerlaw_tiles_struct(params, config_struct, telescope, map_struct_hold, tile_struct)  
     


### PR DESCRIPTION
For the event S200106av, looking at the observation plan produced (cf attached image)![Screenshot from 2020-01-14 10-05-02](https://user-images.githubusercontent.com/44273935/72354481-263aff00-36e6-11ea-8ad4-368c42c520c4.png), it looks crazy. The problem comes from the fact that the skymap and distance error are so small that there are no compatible galaxies. Looking at the gwemopt code it seems that there is a "security" (here: https://github.com/mcoughlin/gwemopt/blob/master/gwemopt/catalog.py#L251) which put Sloc to 1 for all galaxies in such case. This led to point everywhere in the sky. 
This is probably a marginal effect because such skymap comes only from a non-astrophysical event, but it looks weird for people not aware of that to receive such obsplan.

Changes proposed in this pull request:

- catalog.py now output an empty table when no galaxies are compatible. (I did check quickly that thing are working with this output but I did not do any digging with all possibility of the code)
- If there are no compatible galaxies, the ToO_manager code use the 2D probability to compute the tiling obsplan


Other change:
- The mangrove catalog now has an "AGN_flag" column. I added the possibility to output this with  
params["AGN_flag"] = True.