### PR TITLE
adding lastest tools for satellite use, adding few update on mollweide plots

### DIFF
--- a/bin/gwemopt_run
+++ b/bin/gwemopt_run
@@ -107,6 +107,7 @@ def parse_commandline():
                       type=str, default="S")
     parser.add_option("--writeCatalog",  action="store_true", default=False)
     parser.add_option("--catalog_n",default=1.0,type=float)
+    parser.add_option("--AGN_flag", action="store_true",default=False)
     parser.add_option("--doObservability",  action="store_true", default=False)
     parser.add_option("--doSkybrightness",  action="store_true", default=False)
 
@@ -370,6 +371,7 @@ def params_struct(opts):
     params["doCatalogDatabase"] = opts.doCatalogDatabase
     params["galaxy_grade"] = opts.galaxy_grade
     params["writeCatalog"] = opts.writeCatalog
+    params["AGN_flag"] = opts.AGN_flag
 
     params["doChipGaps"] = opts.doChipGaps
     params["doUsePrimary"] = opts.doUsePrimary

--- a/gwemopt/plotting.py
+++ b/gwemopt/plotting.py
@@ -80,7 +80,7 @@ def tauprob(params,tau,prob):
     plt.savefig(plotName,dpi=200)
     plt.close('all')
 
-def tiles(params,map_struct,tiles_structs,plot_sun_moon=True):
+def tiles(params,map_struct,tiles_structs,plot_sun_moon=False):
 
     unit='Gravitational-wave probability'
     cbar=False
@@ -280,7 +280,7 @@ def efficiency(params, map_struct, efficiency_structs):
     plt.savefig(plotName,dpi=200)
     plt.close('all')
 
-def coverage(params, map_struct, coverage_struct, catalog_struct=None,plot_sun_moon=True):
+def coverage(params, map_struct, coverage_struct, catalog_struct=None,plot_sun_moon=False):
 
     unit='Gravitational-wave probability'
     cbar=False

--- a/gwemopt/plotting.py
+++ b/gwemopt/plotting.py
@@ -14,6 +14,7 @@ matplotlib.rcParams['contour.negative_linestyle'] = 'solid'
 import matplotlib.pyplot as plt
 from matplotlib.pyplot import cm
 
+from astropy.coordinates import get_sun, get_moon, SkyCoord
 from gwemopt.segments import angular_distance
 import gwemopt.coverage
 import gwemopt.utils
@@ -79,7 +80,7 @@ def tauprob(params,tau,prob):
     plt.savefig(plotName,dpi=200)
     plt.close('all')
 
-def tiles(params,map_struct,tiles_structs):
+def tiles(params,map_struct,tiles_structs,plot_sun_moon=True):
 
     unit='Gravitational-wave probability'
     cbar=False
@@ -96,6 +97,40 @@ def tiles(params,map_struct,tiles_structs):
             if not patch: continue
             hp.projaxes.HpxMollweideAxes.add_patch(ax,patch)
             #tiles.plot()
+
+    if plot_sun_moon:
+        
+        #plot sun and moon position at the beginning of the observation
+        start_time = params['gpstime'] 
+        start_time = Time(start_time, format='gps', scale='utc')
+
+        sun_position = get_sun(start_time)
+        moon_position = get_moon(start_time)
+
+        hp.visufunc.projscatter(sun_position.ra, sun_position.dec,lonlat=True,color='yellow')
+        hp.visufunc.projscatter(moon_position.ra, moon_position.dec,lonlat=True,color='grey')
+
+        #also plot (in smaller scale) sun and moon position for the 7 following days
+        #This allow to show the path of both sun and moon for the coming days
+        
+        dt = 21600 #1/4 day
+        
+        for i in range(1,29): #29 is 4*7 
+            
+            new_time = params['gpstime'] + (dt*i)
+
+            new_time = Time(new_time, format='gps', scale='utc')
+
+
+            new_moon_position = get_moon(new_time)
+            hp.visufunc.projscatter(new_moon_position.ra, new_moon_position.dec,lonlat=True,color='black',marker='.',s=1)            
+            
+            if not i % 8: #only plot point for the sun every two days in order to avoid overlap
+                new_sun_position = get_sun(new_time)
+                hp.visufunc.projscatter(new_sun_position.ra, new_sun_position.dec,lonlat=True,color='black',marker='.',s=1)
+
+        
+
     add_edges()
     plt.show()
     plt.savefig(plotName,dpi=200)
@@ -245,7 +280,7 @@ def efficiency(params, map_struct, efficiency_structs):
     plt.savefig(plotName,dpi=200)
     plt.close('all')
 
-def coverage(params, map_struct, coverage_struct, catalog_struct=None):
+def coverage(params, map_struct, coverage_struct, catalog_struct=None,plot_sun_moon=True):
 
     unit='Gravitational-wave probability'
     cbar=False
@@ -311,6 +346,38 @@ def coverage(params, map_struct, coverage_struct, catalog_struct=None):
         patch_cpy.set_transform(ax.transData)
         hp.projaxes.HpxMollweideAxes.add_patch(ax,patch_cpy)
         #tiles.plot()
+
+    if plot_sun_moon:
+        
+        #plot sun and moon position at the beginning of the observation
+        start_time = params['gpstime'] 
+        start_time = Time(start_time, format='gps', scale='utc')
+
+        sun_position = get_sun(start_time)
+        moon_position = get_moon(start_time)
+
+        hp.visufunc.projscatter(sun_position.ra, sun_position.dec,lonlat=True,color='yellow')
+        hp.visufunc.projscatter(moon_position.ra, moon_position.dec,lonlat=True,color='grey')
+
+        #also plot (in smaller scale) sun and moon position for the 7 following days
+        #This allow to show the path of both sun and moon for the coming days
+        
+        dt = 21600 #1/4 day
+        
+        for i in range(1,29): #29 is 4*7 
+            
+            new_time = params['gpstime'] + (dt*i)
+
+            new_time = Time(new_time, format='gps', scale='utc')
+
+
+            new_moon_position = get_moon(new_time)
+            hp.visufunc.projscatter(new_moon_position.ra, new_moon_position.dec,lonlat=True,color='black',marker='.',s=1)            
+            
+            if not i % 8: #only plot point for the sun every two days in order to avoid overlap
+                new_sun_position = get_sun(new_time)
+                hp.visufunc.projscatter(new_sun_position.ra, new_sun_position.dec,lonlat=True,color='black',marker='.',s=1)
+        
     plt.show()
     plt.savefig(plotName,dpi=200)
     plt.close('all')
@@ -540,6 +607,39 @@ def coverage(params, map_struct, coverage_struct, catalog_struct=None):
         ax2.legend(loc=1)
     else:
         ax2.legend(loc=1)
+        
+    if plot_sun_moon:
+        
+        #plot sun and moon position at the beginning of the observation
+        start_time = params['gpstime'] 
+        start_time = Time(start_time, format='gps', scale='utc')
+
+        sun_position = get_sun(start_time)
+        moon_position = get_moon(start_time)
+
+        hp.visufunc.projscatter(sun_position.ra, sun_position.dec,lonlat=True,color='yellow')
+        hp.visufunc.projscatter(moon_position.ra, moon_position.dec,lonlat=True,color='grey')
+
+        #also plot (in smaller scale) sun and moon position for the 7 following days
+        #This allow to show the path of both sun and moon for the coming days
+        
+        dt = 21600 #1/4 day
+        
+        for i in range(1,29): #29 is 4*7 
+            
+            new_time = params['gpstime'] + (dt*i)
+
+            new_time = Time(new_time, format='gps', scale='utc')
+
+
+            new_moon_position = get_moon(new_time)
+            hp.visufunc.projscatter(new_moon_position.ra, new_moon_position.dec,lonlat=True,color='black',marker='.',s=1)            
+            
+            if not i % 8: #only plot point for the sun every two days in order to avoid overlap
+                new_sun_position = get_sun(new_time)
+                hp.visufunc.projscatter(new_sun_position.ra, new_sun_position.dec,lonlat=True,color='black',marker='.',s=1)        
+        
+        
     plt.show()
     plt.savefig(plotName,dpi=200)
     plt.close('all')
@@ -582,6 +682,38 @@ def coverage(params, map_struct, coverage_struct, catalog_struct=None):
             patch_cpy.set_alpha(alpha)
         hp.projaxes.HpxMollweideAxes.add_patch(ax,patch_cpy)
         #tiles.plot()
+        
+    if plot_sun_moon:
+        
+        #plot sun and moon position at the beginning of the observation
+        start_time = params['gpstime'] 
+        start_time = Time(start_time, format='gps', scale='utc')
+
+        sun_position = get_sun(start_time)
+        moon_position = get_moon(start_time)
+
+        hp.visufunc.projscatter(sun_position.ra, sun_position.dec,lonlat=True,color='yellow')
+        hp.visufunc.projscatter(moon_position.ra, moon_position.dec,lonlat=True,color='grey')
+
+        #also plot (in smaller scale) sun and moon position for the 7 following days
+        #This allow to show the path of both sun and moon for the coming days
+        
+        dt = 21600 #1/4 day
+        
+        for i in range(1,29): #29 is 4*7 
+            
+            new_time = params['gpstime'] + (dt*i)
+
+            new_time = Time(new_time, format='gps', scale='utc')
+
+
+            new_moon_position = get_moon(new_time)
+            hp.visufunc.projscatter(new_moon_position.ra, new_moon_position.dec,lonlat=True,color='black',marker='.',s=1)            
+            
+            if not i % 8: #only plot point for the sun every two days in order to avoid overlap
+                new_sun_position = get_sun(new_time)
+                hp.visufunc.projscatter(new_sun_position.ra, new_sun_position.dec,lonlat=True,color='black',marker='.',s=1)
+         
     plt.show()
     plt.savefig(plotName,dpi=200)
     plt.close('all')

--- a/gwemopt/segments.py
+++ b/gwemopt/segments.py
@@ -280,6 +280,19 @@ def get_segments(params, config_struct):
     segmentlistdic = segments.segmentlistdict()
     segmentlistdic["observations"] = segmentlist
     segmentlistdic["night"] = nightsegmentlist
+
+    #load the sun retriction for a satelite
+    try:   
+        sat_sun_restriction = config_struct["sat_sun_restriction"]
+    except:
+        sat_sun_restriction = 0.0
+
+    #in the case of satellite use don't intersect with night segment and take all observation time available  
+    if sat_sun_restriction:
+        
+        segmentlist.coalesce()
+        return segmentlist    
+    
     segmentlist = segmentlistdic.intersection(["observations","night"])
     segmentlist.coalesce()
 

--- a/gwemopt/utils.py
+++ b/gwemopt/utils.py
@@ -183,6 +183,9 @@ def params_checker(params):
     if "galaxy_grade" not in params.keys():
         params["galaxy_grade"] = "S"
 
+    if "AGN_flag" not in params.keys():
+        params["AGN_flag"] = False
+
     if "splitType" not in params.keys():
         params["splitType"] = "regional"
 


### PR DESCRIPTION
This pull request contains the following changes:

- Update the mollweide plots in plotting.py in order to get the position of the sun (yellow) and moon (grey) at the beginning of the observations (also plot small dots to show the movement of the sun and the moon in the 7 following days). Example: 
[tiles_coverage.pdf](https://github.com/mcoughlin/gwemopt/files/4880946/tiles_coverage.pdf)

- Add the --AGN_flag parameter in germopt_run in order to output a new column containing AGN info while using mangrove catalog

- Update the tools dedicated to satellite uses (all of them are triggered if there is non null sat_sun_restriction parameter in the config file of the telescope):
    - In segment.py skip the night check for the creation of the segments and keep all day segments
    - In coverage.py check if the the sat_sun_restriction is fulfilled using any king of tilesType (a given pointing has to be sufficiently away from the sun, sat_sun_restriction is in degree)
 

