### PR TITLE
Remove unknown warn= kwarg from matplotlib.use

### DIFF
--- a/bin/gwemopt_run
+++ b/bin/gwemopt_run
@@ -49,7 +49,7 @@ import gwemopt.ztf_coverage
 
 if not os.getenv("DISPLAY", None):
     import matplotlib
-    matplotlib.use("agg", warn=False)
+    matplotlib.use("agg")
 
 __author__ = "Michael Coughlin <michael.coughlin@ligo.org>"
 __version__ = 1.0

--- a/bin/gwemopt_skyvision_to_list
+++ b/bin/gwemopt_skyvision_to_list
@@ -36,7 +36,7 @@ import healpy as hp
 
 if not os.getenv("DISPLAY", None):
     import matplotlib
-    matplotlib.use("agg", warn=False)
+    matplotlib.use("agg")
 
 __author__ = "Michael Coughlin <michael.coughlin@ligo.org>"
 __version__ = 1.0

--- a/bin/run_gwemopt_superscheduler
+++ b/bin/run_gwemopt_superscheduler
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 import matplotlib.patches
 if not os.getenv("DISPLAY", None):
     import matplotlib
-    matplotlib.use("agg", warn=False)
+    matplotlib.use("agg")
 
 __author__ = "Michael Coughlin <michael.coughlin@ligo.org>"
 __version__ = 1.0


### PR DESCRIPTION
The `matplotlib.use()` function does not accept a `warn=` keyword
argument. Fixes the following error message:

    Traceback (most recent call last):
      File "gwemopt_run", line 52, in <module>
        matplotlib.use("agg", warn=False)
    TypeError: use() got an unexpected keyword argument 'warn'